### PR TITLE
Cache data for only an hour

### DIFF
--- a/src/v1/forecast.py
+++ b/src/v1/forecast.py
@@ -8,7 +8,7 @@ from scipy.signal import savgol_filter
 data_dir = "src/v1/data"
 
 
-@st.cache_data
+@st.cache_data(ttl="1h")
 def get_forecast(
     name: str,
     capacity: float,


### PR DESCRIPTION
# Pull Request

## Description

Used keyword `ttl` [parameter](https://github.com/streamlit/streamlit/blob/9bde6fb465da3ae76b628a32c3258cd600949512/lib/streamlit/runtime/caching/cache_data_api.py#L388) ([docs](https://docs.streamlit.io/develop/api-reference/caching-and-state/st.cache_data)) to reduce maximum time to keep the data in the cache to 1hr. No additional dependencies required.

Fixes #46

## How Has This Been Tested?

- [ ] Yes

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
