### PR TITLE
feature: stacked global chart (top 20 + Other)

### DIFF
--- a/src/v1/constants.py
+++ b/src/v1/constants.py
@@ -1,0 +1,21 @@
+"""Constants for the global solar forecast app."""
+
+# OCF colours (palette) - repeat if necessary
+ocf_palette = [
+    "#003f5c",
+    "#2f4b7c",
+    "#665191",
+    "#a05195",
+    "#d45087",
+    "#f95d6a",
+    "#ff7c43",
+    "#ffa600",
+    "#2ca02c",
+    "#1f77b4",
+    "#9467bd",
+    "#8c564b",
+    "#e377c2",
+    "#7f7f7f",
+    "#bcbd22",
+    "#17becf",
+]

--- a/src/v1/main.py
+++ b/src/v1/main.py
@@ -28,7 +28,7 @@ def main_page() -> None:
                 f'<a href="https://www.openclimatefix.org" target="_blank">'
                 f'<img src="data:image/png;base64,{get_image_base64(logo_path)}" '
                 f'style="width: 100%; height: auto; display: block;" />'
-                f'</a>',
+                f"</a>",
                 unsafe_allow_html=True,
             )
 
@@ -144,7 +144,9 @@ def main_page() -> None:
     if not show_stacked:
         fig = go.Figure(
             data=go.Scatter(
-                x=total_forecast["timestamp"], y=total_forecast["power_gw"], marker_color="#FF4901",
+                x=total_forecast["timestamp"],
+                y=total_forecast["power_gw"],
+                marker_color="#FF4901",
             ),
         )
         fig.update_layout(
@@ -157,7 +159,10 @@ def main_page() -> None:
     else:
         # Prepare stacked data: pivot per country
         pivot = all_forecasts_df.pivot_table(
-            index="timestamp", columns="country_code", values="power_gw", aggfunc="sum"
+            index="timestamp",
+            columns="country_code",
+            values="power_gw",
+            aggfunc="sum",
         ).fillna(0)
 
         # pick top N countries by peak contribution
@@ -191,7 +196,7 @@ def main_page() -> None:
         ]
 
         fig = go.Figure()
-        cols = list(stacked_df.columns)
+        cols = list(stacked_df.columns)  # type: ignore[arg-type]
         for i, col in enumerate(cols):
             color = ocf_palette[i % len(ocf_palette)]
             fig.add_trace(
@@ -201,15 +206,15 @@ def main_page() -> None:
                     mode="lines",
                     name=col,
                     stackgroup="one",
-                    line=dict(width=0.5, color=color),
-                )
+                    line={"width": 0.5, "color": color},
+                ),
             )
 
         fig.update_layout(
             yaxis_title="Power [GW]",
             xaxis_title="Time (UTC)",
             yaxis_range=[0, None],
-            legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+            legend={"orientation": "h", "yanchor": "bottom", "y": 1.02, "xanchor": "right", "x": 1},
         )
         st.plotly_chart(fig)
 
@@ -251,12 +256,8 @@ def main_page() -> None:
             f"{selected_timestamp.strftime('%Y-%m-%d %H:%M')} UTC",
         )
 
-        selected_generation = all_forecasts_df[
-            all_forecasts_df["timestamp"] == selected_timestamp
-        ]
-        selected_generation = selected_generation[
-            ["country_code", "power_gw", "power_percentage"]
-        ]
+        selected_generation = all_forecasts_df[all_forecasts_df["timestamp"] == selected_timestamp]
+        selected_generation = selected_generation[["country_code", "power_gw", "power_percentage"]]
     else:
         st.error("No forecast data available for the map")
         return
@@ -290,7 +291,6 @@ def main_page() -> None:
         ),
     )
 
-
     fig.update_layout(
         mapbox_style="carto-positron",
         margin={"r": 0, "t": 0, "l": 0, "b": 0},
@@ -316,6 +316,7 @@ def main_page() -> None:
 def get_image_base64(image_path: str) -> str:
     """Convert image to base64 string for embedding in HTML."""
     import base64
+
     with open(image_path, "rb") as img_file:
         return base64.b64encode(img_file.read()).decode()
 

--- a/src/v1/main.py
+++ b/src/v1/main.py
@@ -9,6 +9,7 @@ import pandas as pd
 import plotly.graph_objects as go
 import pycountry
 import streamlit as st
+from constants import ocf_palette
 from country import country_page
 from forecast import get_forecast
 
@@ -91,6 +92,8 @@ def main_page() -> None:
         lon = centroid.x.values[0]
 
         capacity = solar_capacity_per_country[country.alpha_3]
+        if capacity == 0.0:
+            continue
         forecast_data = get_forecast(country.name, capacity, lat, lon)
 
         if forecast_data is not None:
@@ -174,26 +177,6 @@ def main_page() -> None:
         stacked_df = pivot[top_countries].copy()
         if other_countries:
             stacked_df["Other"] = pivot[other_countries].sum(axis=1)
-
-        # OCF colours (palette) - repeat if necessary
-        ocf_palette = [
-            "#003f5c",
-            "#2f4b7c",
-            "#665191",
-            "#a05195",
-            "#d45087",
-            "#f95d6a",
-            "#ff7c43",
-            "#ffa600",
-            "#2ca02c",
-            "#1f77b4",
-            "#9467bd",
-            "#8c564b",
-            "#e377c2",
-            "#7f7f7f",
-            "#bcbd22",
-            "#17becf",
-        ]
 
         fig = go.Figure()
         cols = list(stacked_df.columns)  # type: ignore[arg-type]

--- a/src/v1/main.py
+++ b/src/v1/main.py
@@ -209,7 +209,6 @@ def main_page() -> None:
             yaxis_title="Power [GW]",
             xaxis_title="Time (UTC)",
             yaxis_range=[0, None],
-            title="Stacked Global Solar Power Forecast (top 20 + Other)",
             legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
         )
         st.plotly_chart(fig)

--- a/src/v1/main.py
+++ b/src/v1/main.py
@@ -110,7 +110,6 @@ def main_page() -> None:
                 # unexpected format; skip this country
                 continue
 
-            # protect against division by zero
             if capacity == 0.0:
                 forecast["power_percentage"] = None
             else:

--- a/src/v1/main.py
+++ b/src/v1/main.py
@@ -9,8 +9,8 @@ import pandas as pd
 import plotly.graph_objects as go
 import pycountry
 import streamlit as st
-from country import country_page
 from constants import ocf_palette
+from country import country_page
 from forecast import get_forecast
 
 data_dir = "src/v1/data"

--- a/src/v1/main.py
+++ b/src/v1/main.py
@@ -9,8 +9,8 @@ import pandas as pd
 import plotly.graph_objects as go
 import pycountry
 import streamlit as st
-from constants import ocf_palette
 from country import country_page
+from constants import ocf_palette
 from forecast import get_forecast
 
 data_dir = "src/v1/data"
@@ -111,10 +111,10 @@ def main_page() -> None:
                 continue
 
             # protect against division by zero
-            try:
-                forecast["power_percentage"] = forecast["power_gw"] / float(capacity) * 100
-            except Exception:
+            if capacity == 0.0:
                 forecast["power_percentage"] = None
+            else:
+                forecast["power_percentage"] = forecast["power_gw"] / float(capacity) * 100
 
             forecast_per_country[country.alpha_3] = forecast
 


### PR DESCRIPTION
# Pull Request

## Description
- added stacked chart for solar capacity for 20 countries + other.
-  Skip countries with zero solar capacity (`if capacity == 0.0: continue`).
- Moved the OCF color palette to a new constants.py file and imported it in main.py.

Fixes #18

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
