### PR TITLE
countries appended

### DIFF
--- a/src/v1/data/get_solar_capacities.py
+++ b/src/v1/data/get_solar_capacities.py
@@ -424,6 +424,177 @@ manual_countries = {
         "capacity_gw": 0.006,
         "source": "www.pv-magazine.com/",
     },
+    # --- Entries supplied by user on 2025-09-26 ---
+    "ATA": {
+        "country_name": "Antarctica",
+        "capacity_gw": 0.0002,
+        "source": "British Antarctic Survey renewable projects 2025 - https://www.bas.ac.uk/media-post/renewables-milestone-reached-in-antarctica/",
+    },
+    "BHS": {
+        "country_name": "Bahamas",
+        "capacity_gw": 0.002,
+        "source": "IRENA Country Profile 2024 - https://www.irena.org/Data/Energy-Profiles",
+    },
+    "BLZ": {
+        "country_name": "Belize",
+        "capacity_gw": 0.002,
+        "source": "IRENA Country Profile 2024 - https://www.irena.org/Data/Energy-Profiles",
+    },
+    "BRN": {
+        "country_name": "Brunei",
+        "capacity_gw": 0.005,
+        "source": "IRENA Country Profile 2024 - https://www.irena.org/Data/Energy-Profiles",
+    },
+    "FLK": {
+        "country_name": "Falkland Islands",
+        "capacity_gw": 0.0034,
+        "source": "Falkland Islands Energy Strategy & green-overseas.org - https://www.green-overseas.org/en/pays-et-territoires/falkland-islands",
+    },
+    "FJI": {
+        "country_name": "Fiji",
+        "capacity_gw": 0.011,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "ATF": {
+        "country_name": "French Southern and Antarctic Lands",
+        "capacity_gw": 0.0032,
+        "source": "green-overseas.org & TAAF renewable energy installations - http://www.green-overseas.org/en/pays-et-territoires/french-southern-and-antarctic-lands",
+    },
+    "GRL": {
+        "country_name": "Greenland",
+        "capacity_gw": 0.001,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "GUY": {
+        "country_name": "Guyana",
+        "capacity_gw": 0.015,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "HTI": {
+        "country_name": "Haiti",
+        "capacity_gw": 0.004,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "ISL": {
+        "country_name": "Iceland",
+        "capacity_gw": 0.007,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "JAM": {
+        "country_name": "Jamaica",
+        "capacity_gw": 0.11,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "KOS": {
+        "country_name": "Kosovo",
+        "capacity_gw": 0.15,
+        "source": "PVKnowhow 2024 & KfW Development Bank - https://www.pvknowhow.com/news/kosovo-solar-plant-keks-impressive-100-mw-project-begins/",
+    },
+    "LAO": {
+        "country_name": "Laos",
+        "capacity_gw": 0.059,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "LBR": {
+        "country_name": "Liberia",
+        "capacity_gw": 0.003,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "NCL": {
+        "country_name": "New Caledonia",
+        "capacity_gw": 0.185,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "NIC": {
+        "country_name": "Nicaragua",
+        "capacity_gw": 0.018,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "NER": {
+        "country_name": "Niger",
+        "capacity_gw": 0.08,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "PRK": {
+        "country_name": "North Korea",
+        "capacity_gw": 0.129,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "CYN": {
+        "country_name": "Northern Cyprus",
+        "capacity_gw": 0.0013,
+        "source": "Research studies ETASR 2023 & ProLuxMax 2025 - https://etasr.com/index.php/ETASR/article/view/5744",
+    },
+    "PSX": {
+        "country_name": "Palestine",
+        "capacity_gw": 0.192,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "PNG": {
+        "country_name": "Papua New Guinea",
+        "capacity_gw": 0.004,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "PRY": {
+        "country_name": "Paraguay",
+        "capacity_gw": 0.001,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "COG": {
+        "country_name": "Republic of the Congo",
+        "capacity_gw": 0.001,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "SLB": {
+        "country_name": "Solomon Islands",
+        "capacity_gw": 0.004,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "SOL": {
+        "country_name": "Somaliland",
+        "capacity_gw": 0.0337,
+        "source": "Combined projects - https://www.greenbuildingafrica.co.za/somaliland-issues-epc-tender-for-12mw-solar-bess-project-plus-13-5km-33kv-evacuation-line/",
+    },
+    "SDS": {
+        "country_name": "South Sudan",
+        "capacity_gw": 0.046,
+        "source": "Combined sources - https://www.saurenergy.me/south-sudan-launches-first-solar-power-plant-with-bess/",
+    },
+    "SUR": {
+        "country_name": "Suriname",
+        "capacity_gw": 0.012,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "SYR": {
+        "country_name": "Syria",
+        "capacity_gw": 0.06,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "TTO": {
+        "country_name": "Trinidad and Tobago",
+        "capacity_gw": 0.004,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "VUT": {
+        "country_name": "Vanuatu",
+        "capacity_gw": 0.005,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "VEN": {
+        "country_name": "Venezuela",
+        "capacity_gw": 0.005,
+        "source": "World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country",
+    },
+    "SAH": {
+        "country_name": "Western Sahara",
+        "capacity_gw": 0.1,
+        "source": "WSRW Report 2024 - https://wsrw.org/en/news/renewable-energy",
+    },
+    "HKG": {
+        "country_name": "Hong Kong",
+        "capacity_gw": 0.19,
+        "source": "TheGlobalEconomy (EIA) - https://www.theglobaleconomy.com/Hong-Kong/solar_electricity_capacity/",
+    },
 }
 
 manual_countries_df = pd.DataFrame.from_dict(manual_countries, orient="index")

--- a/src/v1/data/solar_capacities.csv
+++ b/src/v1/data/solar_capacities.csv
@@ -40,6 +40,7 @@ DEU,89.94,Germany,Ember
 GRC,9.27,Greece,Ember
 HUN,7.7,Hungary,Ember
 IND,97.38,India,Ember
+IDN,0.82,Indonesia,Ember
 IRN,0.78,Iran (Islamic Republic of),Ember
 IRL,1.34,Ireland,Ember
 ITA,36.01,Italy,Ember
@@ -166,3 +167,37 @@ AFG,0.02,Afghanistan,Our World in Data - https://ourworldindata.org/grapher/inst
 BHR,0.05,Bahrain,Our World in Data - https://ourworldindata.org/grapher/installed-solar-pv-capacity
 BTN,0.04,Bhutan,Our World in Data - https://ourworldindata.org/grapher/installed-solar-pv-capacity
 BWA,0.006,Botswana,www.pv-magazine.com/
+ATA,0.0002,Antarctica,British Antarctic Survey renewable projects 2025 - https://www.bas.ac.uk/media-post/renewables-milestone-reached-in-antarctica/
+BHS,0.002,Bahamas,IRENA Country Profile 2024 - https://www.irena.org/Data/Energy-Profiles
+BLZ,0.002,Belize,IRENA Country Profile 2024 - https://www.irena.org/Data/Energy-Profiles
+BRN,0.005,Brunei,IRENA Country Profile 2024 - https://www.irena.org/Data/Energy-Profiles
+FLK,0.0034,Falkland Islands,Falkland Islands Energy Strategy & green-overseas.org - https://www.green-overseas.org/en/pays-et-territoires/falkland-islands
+FJI,0.011,Fiji,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+ATF,0.0032,French Southern and Antarctic Lands,green-overseas.org & TAAF renewable energy installations - http://www.green-overseas.org/en/pays-et-territoires/french-southern-and-antarctic-lands
+GRL,0.001,Greenland,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+GUY,0.015,Guyana,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+HTI,0.004,Haiti,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+ISL,0.007,Iceland,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+JAM,0.11,Jamaica,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+KOS,0.15,Kosovo,PVKnowhow 2024 & KfW Development Bank - https://www.pvknowhow.com/news/kosovo-solar-plant-keks-impressive-100-mw-project-begins/
+LAO,0.059,Laos,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+LBR,0.003,Liberia,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+NCL,0.185,New Caledonia,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+NIC,0.018,Nicaragua,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+NER,0.08,Niger,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+PRK,0.129,North Korea,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+CYN,0.0013,Northern Cyprus,Research studies ETASR 2023 & ProLuxMax 2025 - https://etasr.com/index.php/ETASR/article/view/5744
+PSX,0.192,Palestine,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+PNG,0.004,Papua New Guinea,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+PRY,0.001,Paraguay,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+COG,0.001,Republic of the Congo,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+SLB,0.004,Solomon Islands,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+SOL,0.0337,Somaliland,Combined projects - https://www.greenbuildingafrica.co.za/somaliland-issues-epc-tender-for-12mw-solar-bess-project-plus-13-5km-33kv-evacuation-line/
+SDS,0.046,South Sudan,Combined sources - https://www.saurenergy.me/south-sudan-launches-first-solar-power-plant-with-bess/
+SUR,0.012,Suriname,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+SYR,0.06,Syria,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+TTO,0.004,Trinidad and Tobago,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+VUT,0.005,Vanuatu,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+VEN,0.005,Venezuela,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
+SAH,0.1,Western Sahara,WSRW Report 2024 - https://wsrw.org/en/news/renewable-energy
+HKG,0.19,Hong Kong,TheGlobalEconomy (EIA) - https://www.theglobaleconomy.com/Hong-Kong/solar_electricity_capacity/

--- a/src/v1/main.py
+++ b/src/v1/main.py
@@ -28,7 +28,7 @@ def main_page() -> None:
                 f'<a href="https://www.openclimatefix.org" target="_blank">'
                 f'<img src="data:image/png;base64,{get_image_base64(logo_path)}" '
                 f'style="width: 100%; height: auto; display: block;" />'
-                f'</a>',
+                f"</a>",
                 unsafe_allow_html=True,
             )
 
@@ -123,7 +123,9 @@ def main_page() -> None:
     )
     fig = go.Figure(
         data=go.Scatter(
-            x=total_forecast["timestamp"], y=total_forecast["power_gw"], marker_color="#FF4901",
+            x=total_forecast["timestamp"],
+            y=total_forecast["power_gw"],
+            marker_color="#FF4901",
         ),
     )
     fig.update_layout(
@@ -172,12 +174,8 @@ def main_page() -> None:
             f"{selected_timestamp.strftime('%Y-%m-%d %H:%M')} UTC",
         )
 
-        selected_generation = all_forecasts_df[
-            all_forecasts_df["timestamp"] == selected_timestamp
-        ]
-        selected_generation = selected_generation[
-            ["country_code", "power_gw", "power_percentage"]
-        ]
+        selected_generation = all_forecasts_df[all_forecasts_df["timestamp"] == selected_timestamp]
+        selected_generation = selected_generation[["country_code", "power_gw", "power_percentage"]]
     else:
         st.error("No forecast data available for the map")
         return
@@ -211,7 +209,6 @@ def main_page() -> None:
         ),
     )
 
-
     fig.update_layout(
         mapbox_style="carto-positron",
         margin={"r": 0, "t": 0, "l": 0, "b": 0},
@@ -237,6 +234,7 @@ def main_page() -> None:
 def get_image_base64(image_path: str) -> str:
     """Convert image to base64 string for embedding in HTML."""
     import base64
+
     with open(image_path, "rb") as img_file:
         return base64.b64encode(img_file.read()).decode()
 


### PR DESCRIPTION
# Pull Request

## Description
Added 34 manually‑sourced country solar capacity entries (including Hong Kong — HKG: 0.19 GW) to `get_solar_capacities.py`, regenerated `solar_capacities.csv`.

Fixes #1 #51

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
