### PR TITLE
Add missing solar capacity data for 15 countries

### DIFF
--- a/src/v1/data/get_solar_capacities.py
+++ b/src/v1/data/get_solar_capacities.py
@@ -38,10 +38,20 @@ manual_countries = {
         "capacity_gw": 1.2,
         "source": ("Wikipedia - https://en.wikipedia.org/wiki/Solar_power_by_country"),
     },
+    "TJK": {
+        "country_name": "Tajikistan",
+        "capacity_gw": 0.0006,
+        "source": "CABAR.asia 2024 (600 kW USAID project) - https://cabar.asia/en/tajikistan-solar-energy-in-support-of-hydropower-plants",
+    },
     "TKM": {
         "country_name": "Turkmenistan",
-        "capacity_gw": 0.0,
-        "source": ("The Global Economy - https://www.theglobaleconomy.com/"),
+        "capacity_gw": 0.005,
+        "source": "UNDP 2012 Report - https://www.undp.org/sites/g/files/zskgke326/files/migration/eurasia/Turkmenistan.pdf",
+    },
+    "TLS": {
+        "country_name": "Timor-Leste",
+        "capacity_gw": 0.0011,
+        "source": "Asian Development Bank sector assessment 2016–2020 - https://www.adb.org/sites/default/files/linked-documents/cps-tim-2016-2020-ssa-05.pdf",
     },
     "DZA": {
         "country_name": "Algeria",
@@ -86,8 +96,8 @@ manual_countries = {
     },
     "CPV": {
         "country_name": "Cape Verde",
-        "capacity_gw": 0.03,
-        "source": "https://ember-energy.org/latest-insights/global-electricity-review-2025/",
+        "capacity_gw": 0.026,
+        "source": "IRENA 2023 via PV Magazine - https://www.pv-magazine.com/2024/11/14/cape-verde-runs-tender-for-10-mw-of-solar/",
     },
     "CAF": {
         "country_name": "Central African Republic",
@@ -96,8 +106,8 @@ manual_countries = {
     },
     "COM": {
         "country_name": "Comoros",
-        "capacity_gw": 0.005,
-        "source": "https://www.ren21.net/gsr-2025/downloads/pdf/go/GSR_2025_GO_2025_Full_Report.pdf",
+        "capacity_gw": 0.004034,
+        "source": "IRENA 2023 via PVKnowhow - https://www.pvknowhow.com/solar-report/comoros/",
     },
     "DJI": {
         "country_name": "Djibouti",
@@ -146,8 +156,8 @@ manual_countries = {
     },
     "LES": {
         "country_name": "Lesotho",
-        "capacity_gw": 0.005,
-        "source": "https://ember-energy.org/latest-insights/global-electricity-review-2025/",
+        "capacity_gw": 0.03,
+        "source": "World Bank National Energy Compact 2025 - https://thedocs.worldbank.org/en/doc/038fd851752251bbd12392aa2a6d263c-0010012025/original/Lesotho-National-Energy-Compact-Mission-300.pdf",
     },
     "LSO": {
         "country_name": "Lesotho",
@@ -166,8 +176,8 @@ manual_countries = {
     },
     "STP": {
         "country_name": "Sao Tome and Principe",
-        "capacity_gw": 0.005,
-        "source": "https://www.ren21.net/gsr-2025/downloads/pdf/go/GSR_2025_GO_2025_Full_Report.pdf",
+        "capacity_gw": 0.0036,
+        "source": "World Bank National Energy Compact 2025 - https://thedocs.worldbank.org/en/doc/680a427c0554b887598d86080fdcc775-0010012025/original/Sao-Tome-National-Energy-Compact-Mission-300.pdf",
     },
     "SLE": {
         "country_name": "Sierra Leone",
@@ -181,13 +191,13 @@ manual_countries = {
     },
     "SSD": {
         "country_name": "South Sudan",
-        "capacity_gw": 0.01,
-        "source": "https://www.ren21.net/gsr-2025/downloads/pdf/go/GSR_2025_GO_2025_Full_Report.pdf",
+        "capacity_gw": 0.0384,
+        "source": "Combined: PVKnowhow 2025 (38.4 MW total) - https://www.pvknowhow.com/solar-report/south-sudan/",
     },
     "SYC": {
         "country_name": "Seychelles",
-        "capacity_gw": 0.01,
-        "source": "https://ember-energy.org/latest-insights/global-electricity-review-2025/",
+        "capacity_gw": 0.017,
+        "source": "PVKnowhow 2024 Report - https://www.pvknowhow.com/solar-report/seychelles/",
     },
     "TCD": {
         "country_name": "Chad",
@@ -278,12 +288,15 @@ manual_countries = {
             "Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country"
         ),
     },
+    "MLT": {
+        "country_name": "Malta",
+        "capacity_gw": 0.244,
+        "source": "Malta Regulator for Energy and Water 2024 - https://www.ceer.eu/wp-content/uploads/2024/07/C24_Malta-EN.pdf",
+    },
     "MUS": {
         "country_name": "Mauritius",
-        "capacity_gw": 0.13,
-        "source": (
-            "Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country"
-        ),
+        "capacity_gw": 0.147,
+        "source": "Ministry of Energy Annual Report 2023-2024 - https://publicutilities.govmu.org/Documents/Annual%20Report2023-2024.pdf",
     },
     "NAM": {
         "country_name": "Namibia",
@@ -312,6 +325,11 @@ manual_countries = {
         "source": (
             "Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country"
         ),
+    },
+    "SGP": {
+        "country_name": "Singapore",
+        "capacity_gw": 1.348,
+        "source": "Energy Market Authority Singapore 2024 - https://ema.gov.sg/resources/singapore-energy-statistics/chapter6",
     },
     "TGO": {
         "country_name": "Togo",
@@ -407,10 +425,8 @@ manual_countries = {
     },
     "BHR": {
         "country_name": "Bahrain",
-        "capacity_gw": 0.05,
-        "source": (
-            "Our World in Data - https://ourworldindata.org/grapher/installed-solar-pv-capacity"
-        ),
+        "capacity_gw": 0.065,
+        "source": "IEA Report 2024 via SAU Energy - https://www.saurenergy.me/emerging-middle-eastern-nations-to-advance-re-goals/",
     },
     "BTN": {
         "country_name": "Bhutan",
@@ -595,6 +611,11 @@ manual_countries = {
         "capacity_gw": 0.19,
         "source": "TheGlobalEconomy (EIA) - https://www.theglobaleconomy.com/Hong-Kong/solar_electricity_capacity/",
     },
+    "XKX": {
+        "country_name": "Kosovo",
+        "capacity_gw": 0.09,
+        "source": "PVKnowhow 2025 Report - https://www.pvknowhow.com/news/kosovo-solar-energy-stunning-2025-advancements-proven/",
+    },
 }
 
 manual_countries_df = pd.DataFrame.from_dict(manual_countries, orient="index")
@@ -602,4 +623,4 @@ manual_countries_df.index.name = "country_code"
 
 df = pd.concat([df, manual_countries_df])
 
-df.to_csv("src/v1/data/solar_capacities.csv")
+df.to_csv("solar_capacities.csv")

--- a/src/v1/data/get_solar_capacities.py
+++ b/src/v1/data/get_solar_capacities.py
@@ -51,7 +51,7 @@ manual_countries = {
     "TLS": {
         "country_name": "Timor-Leste",
         "capacity_gw": 0.0011,
-        "source": "Asian Development Bank sector assessment 2016–2020 - https://www.adb.org/sites/default/files/linked-documents/cps-tim-2016-2020-ssa-05.pdf",
+        "source": "Asian Development Bank sector assessment 2016-2020 - https://www.adb.org/sites/default/files/linked-documents/cps-tim-2016-2020-ssa-05.pdf",
     },
     "DZA": {
         "country_name": "Algeria",

--- a/src/v1/data/solar_capacities.csv
+++ b/src/v1/data/solar_capacities.csv
@@ -104,7 +104,9 @@ URY,0.33,Uruguay,Ember
 VNM,18.67,Viet Nam,Ember
 ,1865.49,World,Ember
 UKR,1.2,Ukraine,Wikipedia - https://en.wikipedia.org/wiki/Solar_power_by_country
-TKM,0.0,Turkmenistan,The Global Economy - https://www.theglobaleconomy.com/
+TJK,0.0006,Tajikistan,CABAR.asia 2024 (600 kW USAID project) - https://cabar.asia/en/tajikistan-solar-energy-in-support-of-hydropower-plants
+TKM,0.005,Turkmenistan,UNDP 2012 Report - https://www.undp.org/sites/g/files/zskgke326/files/migration/eurasia/Turkmenistan.pdf
+TLS,0.0011,Timor-Leste,Asian Development Bank sector assessment 2016–2020 - https://www.adb.org/sites/default/files/linked-documents/cps-tim-2016-2020-ssa-05.pdf
 DZA,0.46,Algeria,Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country
 SEN,0.23,Senegal,Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country
 AGO,0.31,Angola,Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country
@@ -112,9 +114,9 @@ BEN,0.13,Benin,https://ember-energy.org/latest-insights/global-electricity-revie
 BFA,0.09,Burkina Faso,https://ember-energy.org/latest-insights/global-electricity-review-2025/
 BDI,0.017,Burundi,https://ember-energy.org/latest-insights/global-electricity-review-2025/
 CMR,0.09,Cameroon,https://ember-energy.org/latest-insights/the-first-evidence-of-a-take-off-in-solar-in-africa/
-CPV,0.03,Cape Verde,https://ember-energy.org/latest-insights/global-electricity-review-2025/
+CPV,0.026,Cape Verde,IRENA 2023 via PV Magazine - https://www.pv-magazine.com/2024/11/14/cape-verde-runs-tender-for-10-mw-of-solar/
 CAF,0.01,Central African Republic,https://ember-energy.org/latest-insights/the-first-evidence-of-a-take-off-in-solar-in-africa/
-COM,0.005,Comoros,https://www.ren21.net/gsr-2025/downloads/pdf/go/GSR_2025_GO_2025_Full_Report.pdf
+COM,0.004034,Comoros,IRENA 2023 via PVKnowhow - https://www.pvknowhow.com/solar-report/comoros/
 DJI,0.02,Djibouti,https://ember-energy.org/latest-insights/global-electricity-review-2025/
 ERI,0.01,Eritrea,https://ember-energy.org/latest-insights/the-first-evidence-of-a-take-off-in-solar-in-africa/
 SWZ,0.03,Eswatini,https://www.globalsolarcouncil.org/news/global-solar-council-africas-solar-market-set-to-surge-42-in-2025-but-finance-bottlenecks-threaten-growth/
@@ -124,15 +126,15 @@ GNQ,0.005,Equatorial Guinea,https://www.ren21.net/gsr-2025/downloads/pdf/go/GSR_
 GIN,0.01,Guinea,https://ember-energy.org/latest-insights/global-electricity-review-2025/
 GNB,0.005,Guinea-Bissau,https://www.ren21.net/gsr-2025/downloads/pdf/go/GSR_2025_GO_2025_Full_Report.pdf
 CIV,0.05,Ivory Coast,https://ember-energy.org/latest-insights/global-electricity-review-2025/
-LES,0.005,Lesotho,https://ember-energy.org/latest-insights/global-electricity-review-2025/
+LES,0.03,Lesotho,World Bank National Energy Compact 2025 - https://thedocs.worldbank.org/en/doc/038fd851752251bbd12392aa2a6d263c-0010012025/original/Lesotho-National-Energy-Compact-Mission-300.pdf
 LSO,0.005,Lesotho,https://ember-energy.org/latest-insights/global-electricity-review-2025/
 MRT,0.04,Mauritania,https://ember-energy.org/latest-insights/global-electricity-review-2025/
 MWI,0.03,Malawi,https://www.ren21.net/gsr-2025/downloads/pdf/go/GSR_2025_GO_2025_Full_Report.pdf
-STP,0.005,Sao Tome and Principe,https://www.ren21.net/gsr-2025/downloads/pdf/go/GSR_2025_GO_2025_Full_Report.pdf
+STP,0.0036,Sao Tome and Principe,World Bank National Energy Compact 2025 - https://thedocs.worldbank.org/en/doc/680a427c0554b887598d86080fdcc775-0010012025/original/Sao-Tome-National-Energy-Compact-Mission-300.pdf
 SLE,0.02,Sierra Leone,https://ember-energy.org/latest-insights/the-first-evidence-of-a-take-off-in-solar-in-africa/
 SOM,0.02,Somalia,https://ember-energy.org/latest-insights/the-first-evidence-of-a-take-off-in-solar-in-africa/
-SSD,0.01,South Sudan,https://www.ren21.net/gsr-2025/downloads/pdf/go/GSR_2025_GO_2025_Full_Report.pdf
-SYC,0.01,Seychelles,https://ember-energy.org/latest-insights/global-electricity-review-2025/
+SSD,0.0384,South Sudan,Combined: PVKnowhow 2025 (38.4 MW total) - https://www.pvknowhow.com/solar-report/south-sudan/
+SYC,0.017,Seychelles,PVKnowhow 2024 Report - https://www.pvknowhow.com/solar-report/seychelles/
 TCD,0.02,Chad,https://ember-energy.org/latest-insights/the-first-evidence-of-a-take-off-in-solar-in-africa/
 ALB,0.21,Albania,Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country
 COD,0.03,Dem. Rep. Congo,Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country
@@ -146,11 +148,13 @@ ISR,5.52,Israel,Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Sola
 JOR,2.59,Jordan,Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country
 LBN,1.0,Lebanon,Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country
 MLI,0.1,Mali,Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country
-MUS,0.13,Mauritius,Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country
+MLT,0.244,Malta,Malta Regulator for Energy and Water 2024 - https://www.ceer.eu/wp-content/uploads/2024/07/C24_Malta-EN.pdf
+MUS,0.147,Mauritius,Ministry of Energy Annual Report 2023-2024 - https://publicutilities.govmu.org/Documents/Annual%20Report2023-2024.pdf
 NAM,0.16,Namibia,Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country
 NPL,0.25,Nepal,Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country
 PAN,0.65,Panama,Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country
 SDN,0.19,Sudan,Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country
+SGP,1.348,Singapore,Energy Market Authority Singapore 2024 - https://ema.gov.sg/resources/singapore-energy-statistics/chapter6
 TGO,0.07,Togo,Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country
 UZB,3.8,Uzbekistan,Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country
 YEM,0.29,Yemen,Wikipedia (Ember 2024 data) - https://en.wikipedia.org/wiki/Solar_power_by_country
@@ -164,7 +168,7 @@ TZA,0.02,Tanzania,Our World in Data - https://ourworldindata.org/grapher/install
 UGA,0.04,Uganda,Our World in Data - https://ourworldindata.org/grapher/installed-solar-pv-capacity
 ZWE,0.09,Zimbabwe,Our World in Data - https://ourworldindata.org/grapher/installed-solar-pv-capacity
 AFG,0.02,Afghanistan,Our World in Data - https://ourworldindata.org/grapher/installed-solar-pv-capacity
-BHR,0.05,Bahrain,Our World in Data - https://ourworldindata.org/grapher/installed-solar-pv-capacity
+BHR,0.065,Bahrain,IEA Report 2024 via SAU Energy - https://www.saurenergy.me/emerging-middle-eastern-nations-to-advance-re-goals/
 BTN,0.04,Bhutan,Our World in Data - https://ourworldindata.org/grapher/installed-solar-pv-capacity
 BWA,0.006,Botswana,www.pv-magazine.com/
 ATA,0.0002,Antarctica,British Antarctic Survey renewable projects 2025 - https://www.bas.ac.uk/media-post/renewables-milestone-reached-in-antarctica/
@@ -201,3 +205,4 @@ VUT,0.005,Vanuatu,World Population Review 2025 - https://worldpopulationreview.c
 VEN,0.005,Venezuela,World Population Review 2025 - https://worldpopulationreview.com/country-rankings/solar-power-by-country
 SAH,0.1,Western Sahara,WSRW Report 2024 - https://wsrw.org/en/news/renewable-energy
 HKG,0.19,Hong Kong,TheGlobalEconomy (EIA) - https://www.theglobaleconomy.com/Hong-Kong/solar_electricity_capacity/
+XKX,0.09,Kosovo,PVKnowhow 2025 Report - https://www.pvknowhow.com/news/kosovo-solar-energy-stunning-2025-advancements-proven/


### PR DESCRIPTION
# Pull Request

## Description
Added 15 more countries
Updated countries that had capacity=0.0
untouched the filter for countries having capacity=0.0
Fixes #1 #51 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
