### PR TITLE
Fix hover label to show correct unit (% or GW) based on normalization

### DIFF
--- a/src/v1/main.py
+++ b/src/v1/main.py
@@ -276,6 +276,9 @@ def main_page() -> None:
 
     shapes_dict = json.loads(world.to_json())
 
+    # Determine unit for hover template
+    unit = "%" if normalized else "GW"
+
     fig = go.Figure(
         data=go.Choroplethmap(
             geojson=shapes_dict,
@@ -289,7 +292,7 @@ def main_page() -> None:
             ],
             colorbar_title="Power [%]" if normalized else "Power [GW]",
             marker_opacity=0.5,
-            hovertemplate="<b>%{customdata}</b><br>Power: %{z:.2f} GW<extra></extra>",
+            hovertemplate=f"<b>%{{customdata}}</b><br>Power: %{{z:.2f}} {unit}<extra></extra>",
             customdata=world["country_name"]
             if "country_name" in world.columns
             else world["adm0_a3"],


### PR DESCRIPTION
# Pull Request

## Description

 resolved the hover label bug where the map tooltip was showing "GW" instead of "%" when normalization was enabled.

Fixes #40 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
