### PR TITLE
Upgrade capacities table to dynamic sortable dataframe

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -78,9 +78,18 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "jasondrury22",
+      "name": "Jason Drury",
+      "avatar_url": "https://avatars.githubusercontent.com/u/18755314?v=4&size=64",
+      "profile": "https://github.com/jasondrury22",
+      "contributions": [
+        "code"
+      ]
     }
   ],
-  "contributorsPerLine": 7,
+  "contributorsPerLine": 8,
   "skipCi": true,
   "repoType": "github",
   "repoHost": "https://github.com",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "pylsp-mypy",
     "python-lsp-ruff",
     "scipy-stubs",
+    "types-pytz>=2025.2.0.20251108",
 ]
 
 [project.scripts]

--- a/src/v1/main.py
+++ b/src/v1/main.py
@@ -428,7 +428,7 @@ def format_html_link(html_str):
 
     # Extract the URL and the inner text
     url_match = re.search(r'href="([^"]+)"', html_str)
-    text_match = re.search(r'>([^<]+)</a>', html_str)
+    text_match = re.search(r">([^<]+)</a>", html_str)
 
     if url_match and text_match:
         url = url_match.group(1)
@@ -479,7 +479,7 @@ def capacities_page() -> None:
         return name
 
     solar_capacity_per_country_df["source_link"] = solar_capacity_per_country_df.apply(
-        create_source_link, axis=1
+        create_source_link, axis=1,
     )
 
     # Create display dataframe with country_code as proper column
@@ -501,9 +501,9 @@ def capacities_page() -> None:
         column_config={
             "Source": st.column_config.LinkColumn(
                 "Source",
-                display_text=r".*#(.*)"
-            )
-        }
+                display_text=r".*#(.*)",
+            ),
+        },
     )
 
 

--- a/src/v1/main.py
+++ b/src/v1/main.py
@@ -438,13 +438,13 @@ def capacities_page() -> None:
     solar_capacity_per_country_df.drop(columns=["temp"], inplace=True)
 
     # Parse markdown links [text](url) into separate columns for display
-    def parse_markdown_link(source: str) -> tuple[str, str]:
+    def parse_markdown_link(source: str | float | None) -> tuple[str, str]:
         """Extract text and URL from markdown link format."""
         if pd.isna(source):
             return ("", "")
         match = re.match(r"\[([^\]]+)\]\(([^)]+)\)", str(source))
         if match:
-            return (match.group(1), match.group(2))
+            return (str(match.group(1)), str(match.group(2)))
         # If not markdown format, return as-is
         return (str(source), "")
 
@@ -456,9 +456,9 @@ def capacities_page() -> None:
     # Create HTML clickable links for source column
     def create_source_link(row: pd.Series) -> str:
         """Create URL#TEXT format for Streamlit LinkColumn."""
-        name = row["source_name"]
-        url = row["source_url"]
-        if url:
+        name = str(row["source_name"])
+        url = str(row["source_url"])
+        if url and url != "None" and url != "":
             # Changed from to the hash format Streamlit needs
             return f"{url}#{name}"
         return name

--- a/src/v1/main.py
+++ b/src/v1/main.py
@@ -489,11 +489,14 @@ def capacities_page() -> None:
     display_df = display_df.reset_index()  # Move country_code from index to column
     display_df.columns = ["Country Code", "Capacity (GW)", "Country", "Source"]
 
+    # initial presort by Capacity
+    display_df = display_df.sort_values(by="Capacity (GW)", ascending=False)
+
     # Display the dataframe with the custom LinkColumn and no scroll container
     st.dataframe(
         display_df,
         hide_index=True,
-        use_container_width=True,  # Spreads the table nicely across the page
+        width="stretch",  # Spreads the table nicely across the page
         height="content",  # Removes the scrollable container box
         column_config={
             "Source": st.column_config.LinkColumn(

--- a/src/v1/main.py
+++ b/src/v1/main.py
@@ -422,6 +422,21 @@ def docs_page() -> None:
     faqs = Path("./FAQ.md").read_text()
     st.markdown(faqs)
 
+def format_html_link(html_str):
+    if not isinstance(html_str, str) or "<a " not in html_str:
+        return html_str
+
+    # Extract the URL and the inner text
+    url_match = re.search(r'href="([^"]+)"', html_str)
+    text_match = re.search(r'>([^<]+)</a>', html_str)
+
+    if url_match and text_match:
+        url = url_match.group(1)
+        text = text_match.group(1)
+        # Combine them: URL#TEXT
+        return f"{url}#{text}"
+    return html_str
+
 
 def capacities_page() -> None:
     """Solar capacities page."""
@@ -455,11 +470,12 @@ def capacities_page() -> None:
 
     # Create HTML clickable links for source column
     def create_source_link(row: pd.Series) -> str:
-        """Create HTML link with source name as clickable text."""
+        """Create URL#TEXT format for Streamlit LinkColumn."""
         name = row["source_name"]
         url = row["source_url"]
         if url:
-            return f'<a href="{url}" target="_blank">{name}</a>'
+            # Changed from to the hash format Streamlit needs
+            return f"{url}#{name}"
         return name
 
     solar_capacity_per_country_df["source_link"] = solar_capacity_per_country_df.apply(
@@ -473,11 +489,20 @@ def capacities_page() -> None:
     display_df = display_df.reset_index()  # Move country_code from index to column
     display_df.columns = ["Country Code", "Capacity (GW)", "Country", "Source"]
 
-    # Display as HTML table with clickable links
-    st.markdown(
-        display_df.to_html(escape=False, index=False),
-        unsafe_allow_html=True,
+    # Display the dataframe with the custom LinkColumn and no scroll container
+    st.dataframe(
+        display_df,
+        hide_index=True,
+        use_container_width=True,  # Spreads the table nicely across the page
+        height="content",  # Removes the scrollable container box
+        column_config={
+            "Source": st.column_config.LinkColumn(
+                "Source",
+                display_text=r".*#(.*)"
+            )
+        }
     )
+
 
 
 

--- a/src/v1/main.py
+++ b/src/v1/main.py
@@ -453,7 +453,7 @@ def capacities_page() -> None:
     solar_capacity_per_country_df["source_name"] = parsed.apply(lambda x: x[0])
     solar_capacity_per_country_df["source_url"] = parsed.apply(lambda x: x[1])
 
-    # Create HTML clickable links for source column
+    # Create LinkColumn-compatible values (URL#TEXT) for source column
     def create_source_link(row: pd.Series) -> str:
         """Create URL#TEXT format for Streamlit LinkColumn."""
         name = str(row["source_name"])

--- a/src/v1/main.py
+++ b/src/v1/main.py
@@ -422,21 +422,6 @@ def docs_page() -> None:
     faqs = Path("./FAQ.md").read_text()
     st.markdown(faqs)
 
-def format_html_link(html_str):
-    if not isinstance(html_str, str) or "<a " not in html_str:
-        return html_str
-
-    # Extract the URL and the inner text
-    url_match = re.search(r'href="([^"]+)"', html_str)
-    text_match = re.search(r">([^<]+)</a>", html_str)
-
-    if url_match and text_match:
-        url = url_match.group(1)
-        text = text_match.group(1)
-        # Combine them: URL#TEXT
-        return f"{url}#{text}"
-    return html_str
-
 
 def capacities_page() -> None:
     """Solar capacities page."""

--- a/src/v1/main.py
+++ b/src/v1/main.py
@@ -459,7 +459,7 @@ def capacities_page() -> None:
         name = str(row["source_name"])
         url = str(row["source_url"])
         if url and url != "None" and url != "":
-            # Changed from to the hash format Streamlit needs
+            # Use the hash format Streamlit's LinkColumn expects
             return f"{url}#{name}"
         return name
 


### PR DESCRIPTION
# Pull Request

## Description

This PR upgrades the static capacities table on the `capacities_page` to a dynamic `st.dataframe`, allowing users to sort the data by column headers (e.g., Capacity, County, County Code, Source).

**Key Changes:**
* Replaced `st.markdown(...to_html...)` with `st.dataframe()` using modern layout parameters (`width="stretch"`, `height="content"`).
* Implemented `st.column_config.LinkColumn` to cleanly render the Ember markdown links as clickable text using a regex extraction (`.*#(.*)`).
* Added a pre-sort step (`sort_values`) so the table loads with the highest capacity countries at the top by default.

Fixes # https://github.com/openclimatefix/global-solar-forecast/issues/90  Update table to make it dynamic

## How Has This Been Tested?
- Ran the Streamlit application locally.
- Verified that all dataframe columns are natively sortable upon clicking the headers.
- Clicked multiple links in the "Source" column to ensure they correctly open the external data catalogue pages in a new tab.
- Verified the initial page load displays the data pre-sorted by highest capacity.

No unit tests have been created for this app.  I plan to look into adding it in a future PR.

### Visual Demo
https://github.com/user-attachments/assets/275a9e4a-e1a0-466e-88d6-121a17998b10


## Checklist:

- [ X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ X] I have checked my code and corrected any misspellings

