### PR TITLE
fix: apply Matter font to all Plotly chart text

### DIFF
--- a/src/v1/country.py
+++ b/src/v1/country.py
@@ -261,6 +261,7 @@ def country_page() -> None:
         xaxis_title="Local Time",
         yaxis_range=[0, None],
         title=f"Solar Forecast for {country.name} (Local Time)",
+        font={"family": "MatterXH, Arial, sans-serif"},
     )
 
     st.plotly_chart(fig)

--- a/src/v1/main.py
+++ b/src/v1/main.py
@@ -185,6 +185,7 @@ def main_page() -> None:
             xaxis_title="Time (UTC)",
             yaxis_range=[0, None],
             title="Global Solar Power Forecast",
+            font={"family": "MatterXH, Arial, sans-serif"},
         )
         st.plotly_chart(fig)
     else:
@@ -240,7 +241,11 @@ def main_page() -> None:
                 "x": 1,
             },
             hovermode="x unified",
-            hoverlabel={"namelength": 20, "font": {"size": 12}},
+            hoverlabel={
+                "namelength": 20,
+                "font": {"size": 12, "family": "MatterXH, Arial, sans-serif"},
+            },
+            font={"family": "MatterXH, Arial, sans-serif"},
         )
         st.plotly_chart(fig)
 
@@ -356,6 +361,7 @@ def main_page() -> None:
             "showocean": True,
             "oceancolor": "rgba(0,0,0,0)",
         },
+        font={"family": "MatterXH, Arial, sans-serif"},
     )
 
     clicked_data = st.plotly_chart(fig, on_select="rerun", key="world_map")


### PR DESCRIPTION
Plotly doesn't inherit page CSS, so chart titles, axis labels, tick labels, and hover text were unaffected by the global MatterXH CSS. Adds font.family to update_layout() on all four figures.

Closes #89

# Pull Request

## Description

Plotly renders in its own JS context and does not inherit CSS from the page. The global MatterXH CSS applied in #95 correctly styled native Streamlit/HTML elements, but Plotly chart text (axis titles, tick labels, chart titles, legend entries, hover tooltips) was left unchanged.

Fix: added font={"family": "MatterXH, Arial, sans-serif"} to update_layout() on all four Plotly figures across main.py and country.py.

Fixes #89

## How Has This Been Tested?

Ran the app locally with uv run streamlit run src/v1/main.py and visually confirmed the Matter font is now applied to all chart text: titles, axis labels, tick labels, legend, and hover tooltips on the global forecast chart, stacked area chart, world map, and per-country forecast chart.

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

No effect on data processing.

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
